### PR TITLE
Add compatibility with older BusyBox versions (e.g. v1.7.2 on Kindle K4 NT)

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -102,17 +102,17 @@ function Filebrowser:start()
 end
 
 function Filebrowser:isRunning()
-    -- Use start-stop-daemon -K (to stop a process) in --test mode to find if
-    -- there are any matching processes for this pidfile and executable. If
-    -- there are any matching processes, this exits with status code 0.
+    -- Run start-stop-daemon in “stop” mode (-K) with signal 0 (no-op)
+    -- to test whether any process matches this pidfile and executable.
+    -- Exit code: 0 → at least one process found, 1 → none found.
     local cmd = string.format(
-        "start-stop-daemon -K -o -s 0 -p %s -x %s",
+        "start-stop-daemon -K -s 0 -p %s -x %s",
         pidFilePath,
         binPath
     )
 
     logger.dbg("[Filebrowser] Check if Filebrowser is running: ", cmd)
-    
+
     local status = os.execute(cmd)
 
     logger.dbg("[Filebrowser] Running status exit code (0 -> running): ", status)

--- a/main.lua
+++ b/main.lua
@@ -53,10 +53,10 @@ function Filebrowser:start()
     -- and a log file.
     local cmd = string.format(
         "start-stop-daemon -S "
-        .. "--make-pidfile --pidfile %s " -- pidFilePath
-        .. "--oknodo "
-        .. "--background "
-        .. "--exec %s " -- binPath
+        .. "-m -p %s " -- pidFilePath
+        .. "-o "
+        .. "-b "
+        .. "-x %s " -- binPath
         .. "-- "
         .. "-a 0.0.0.0 "
         .. "-r %s " -- dataPath
@@ -106,7 +106,7 @@ function Filebrowser:isRunning()
     -- there are any matching processes for this pidfile and executable. If
     -- there are any matching processes, this exits with status code 0.
     local cmd = string.format(
-        "start-stop-daemon --pidfile %s --exec %s -K --test",
+        "start-stop-daemon -K -o -s 0 -p %s -x %s",
         pidFilePath,
         binPath
     )
@@ -124,7 +124,7 @@ function Filebrowser:stop()
     -- Use start-stop-daemon -K to stop the process, with --oknodo to exit with
     -- status code 0 if there are no matching processes in the first place.
     local cmd = string.format(
-        "start-stop-daemon --pidfile %s --exec %s --oknodo -K",
+        "start-stop-daemon -K -o -p %s -x %s",
         pidFilePath,
         binPath
     )

--- a/main.lua
+++ b/main.lua
@@ -135,10 +135,10 @@ function Filebrowser:stop()
     if Device:isKindle() then
     logger.dbg("[Filebrowser] Closing port: ", filebrowser_port)
         os.execute(string.format("%s %s %s",
-            "iptables -D INPUT -p tcp --dport", self.SSH_port,
+            "iptables -D INPUT -p tcp --dport", self.filebrowser_port,
             "-m conntrack --ctstate NEW,ESTABLISHED -j ACCEPT"))
         os.execute(string.format("%s %s %s",
-            "iptables -D OUTPUT -p tcp --sport", self.SSH_port,
+            "iptables -D OUTPUT -p tcp --sport", self.filebrowser_port,
             "-m conntrack --ctstate ESTABLISHED -j ACCEPT"))
     end
     local status = os.execute(cmd)


### PR DESCRIPTION
I’m submitting some improvements to ensure compatibility with older versions of BusyBox, such as the one found on my very old Kindle K4 NT (BusyBox v1.7.2). I encountered issues similar to those reported in open issues.

One major issue is that even though the start-stop-daemon --help output lists long options like --pidfile, --make-pidfile, and --exec, they **are not actually supported** in this version. Attempting to use them results in:

```
start-stop-daemon: unrecognized option '--pidfile'
start-stop-daemon: unrecognized option '--make-pidfile'
start-stop-daemon: unrecognized option '--exec'
```


This misleading behavior from the built-in help made troubleshooting more difficult.

To fix this, I replaced all long options with their short equivalents (e.g. `-p`,` -m`,` -x`), which are correctly supported by these older BusyBox versions.

Additionally, since the `--test` option is not available, I simulated its functionality by sending signal 0 with `kill -s 0`.

I also discovered that on very old Linux kernels (such as the one on the Kindle K4), the filebrowser executable does not work because some Go libraries it depends on have dropped support for legacy kernels. As a workaround, I’m currently working on a much simpler file browser written in Rust, using libraries that still support these older systems. While not as feature-rich, it will provide basic file browsing functionality even on legacy devices like the Kindle K4.

Changes in this PR:

- Fixed incorrect iptables ports in delete rules (they were mistakenly targeting SSH ports).
- Replaced unsupported long options in `start-stop-daemon` with short equivalents to restore compatibility.
- Simulated the` --test` behavior using `-s 0` as a workaround.